### PR TITLE
reduce API surface

### DIFF
--- a/govnr_test.go
+++ b/govnr_test.go
@@ -29,69 +29,6 @@ func TestOnce_ReportsOnPanic(t *testing.T) {
 
 }
 
-func TestGoForever_ReportsOnPanicAndRestarts(t *testing.T) {
-	numOfIterations := 10
-
-	logger := mockLogger()
-	ctx, cancel := context.WithCancel(context.Background())
-
-	count := 0
-
-	require.NotPanicsf(t, func() {
-		GoForever(ctx, logger, func() {
-			if count > numOfIterations {
-				cancel()
-			} else {
-				count++
-			}
-			panic("foo")
-		})
-	}, "GoForever panicked unexpectedly")
-
-	for i := 0; i < numOfIterations; i++ {
-		select {
-		case report := <-logger.errors:
-			require.Error(t, report.err)
-		case <-time.After(1 * time.Second):
-			require.Fail(t, "long living goroutine didn't restart")
-		}
-	}
-}
-
-func TestGoForever_TerminatesWhenContextIsClosed(t *testing.T) {
-	logger := mockLogger()
-	ctx, cancel := context.WithCancel(context.Background())
-
-	bgStarted := make(chan struct{})
-	bgEnded := make(chan struct{})
-	shutdown := GoForever(ctx, logger, func() {
-		bgStarted <- struct{}{}
-		select {
-		case <-ctx.Done():
-			bgEnded <- struct{}{}
-			return
-		}
-	})
-
-	<-bgStarted
-	cancel()
-
-	select {
-	case <-bgEnded:
-		// ok, invocation of cancel() caused goroutine to stop, we can now check if it restarts
-	case <-time.After(1 * time.Second):
-		require.Fail(t, "long living goroutine didn't stop")
-	}
-
-	select {
-	case <-shutdown:
-		// system has shutdown, all ok
-	case <-time.After(1 * time.Second):
-		t.Fatalf("long living goroutine did not return")
-	}
-
-}
-
 func TestForever_ReportsOnPanicAndRestarts(t *testing.T) {
 	numOfIterations := 10
 

--- a/once.go
+++ b/once.go
@@ -10,16 +10,7 @@ type Errorer interface {
 	Error(err error)
 }
 
-type ContextEndedChan chan struct{}
-
-// Runs f() in a new goroutine; if it panics, logs the error and stack trace to the specified Errorer
-//
-// Deprecated; use Once instead
-func GoOnce(errorHandler Errorer, f func()) {
-	go func() {
-		tryOnce(errorHandler, f)
-	}()
-}
+type ContextEndedChan <-chan struct{}
 
 // Runs f() in a new goroutine; if it panics, logs the error and stack trace to the specified Errorer
 func Once(errorHandler Errorer, f func()) {


### PR DESCRIPTION
 - make ContextEndedChan read-only channel (not closeable by consumer)
 - delete deprecated `GoOnce` and `GoForever` functions